### PR TITLE
Fix genre_spec.rb test that is causing confusion for students

### DIFF
--- a/spec/features/genre_spec.rb
+++ b/spec/features/genre_spec.rb
@@ -27,7 +27,7 @@ describe 'form' do
     expect(page).to have_content("My genre name")
   end
 
-  it 'shows a new form that submits content and redirects and prints out params' do
+  it 'shows an edit form that submits content and redirects and prints out params' do
     @genre = Genre.create(name: "My Genre")
 
     visit edit_genre_path(@genre)


### PR DESCRIPTION
The final test in `genre_spec.rb` uses the same wording as the previous test. The test for the new form and edit form have the same wording.

`it 'shows a new form that submits content and redirects and prints out params'`

This is a causing confusion for students as they think something is wrong with their new genre form when the issue is actually their edit genre form.

Updated the wording for the edit form test to instead read:

`it 'shows an edit form that submits content and redirects and prints out params'`